### PR TITLE
Thème sombre

### DIFF
--- a/style/ikurso.css
+++ b/style/ikurso.css
@@ -288,6 +288,14 @@ table.highlight>tbody>tr:hover{
 /****************************************/
 /*           blocs principaux           */
 /****************************************/
+html {
+	color-scheme: light dark;
+	background-color: canvas;
+	color: canvastext;
+}
+.card-panel {
+	color: black;
+}
 body {
     display: flex;
     min-height: 100vh;


### PR DESCRIPTION
Une mini modif qui rajoute un thème sombre au site si le navigateur est configuré pour afficher les pages en sombre.

![bildo](https://github.com/user-attachments/assets/beab1cba-0df7-420a-bc58-60f8bf248813)

Je n'ai pas réussi à lancer le serveur en local (pas xampp ni mysql etc) donc à modifier en fonction de ce qui est le mieux!

Intéressant https://developer.mozilla.org/en-US/docs/Web/CSS/system-color
